### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/110/895/260/3/1108952603.geojson
+++ b/data/110/895/260/3/1108952603.geojson
@@ -232,6 +232,9 @@
     "wof:capital_of":85632331,
     "wof:concordances":{},
     "wof:country":"PW",
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"cdac23e455a51118c19d613ff978ebfc",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
         }
     ],
     "wof:id":1108952603,
-    "wof:lastmodified":1566609232,
+    "wof:lastmodified":1582359969,
     "wof:name":"Ngerulmud",
     "wof:parent_id":85676471,
     "wof:placetype":"locality",

--- a/data/421/188/979/421188979.geojson
+++ b/data/421/188/979/421188979.geojson
@@ -241,6 +241,9 @@
     },
     "wof:country":"PW",
     "wof:created":1459009595,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"6d73b12fa4715dbeec32b2245b3d7e86",
     "wof:hierarchy":[
         {
@@ -249,7 +252,7 @@
         }
     ],
     "wof:id":421188979,
-    "wof:lastmodified":1566609232,
+    "wof:lastmodified":1582359969,
     "wof:name":"Koror",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/323/31/85632331.geojson
+++ b/data/856/323/31/85632331.geojson
@@ -876,6 +876,10 @@
     },
     "wof:country":"PW",
     "wof:country_alpha3":"PLW",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"ed313f141b085519b37e8572d7c7c3ad",
     "wof:hierarchy":[
         {
@@ -892,7 +896,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1566609228,
+    "wof:lastmodified":1582359969,
     "wof:name":"Palau",
     "wof:parent_id":102191583,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.