### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/114/190/838/7/1141908387.geojson
+++ b/data/114/190/838/7/1141908387.geojson
@@ -21,16 +21,31 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0631\u0648\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0631\u0648\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Koror"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u043e\u0440\u0430\u0440"
     ],
+    "name:bel_x_variant":[
+        "\u041a\u043e\u0440\u0430\u0440"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09cb\u09b0\u09cb\u09b0"
+    ],
+    "name:bul_x_preferred":[
+        "\u041a\u043e\u0440\u043e\u0440"
     ],
     "name:cat_x_preferred":[
         "Koror"
     ],
     "name:ceb_x_preferred":[
+        "Koror"
+    ],
+    "name:ces_x_preferred":[
         "Koror"
     ],
     "name:dan_x_preferred":[
@@ -75,6 +90,9 @@
     "name:hun_x_preferred":[
         "Koror"
     ],
+    "name:hye_x_preferred":[
+        "\u0554\u0578\u0580\u0578\u0580"
+    ],
     "name:ind_x_preferred":[
         "Koror"
     ],
@@ -93,10 +111,19 @@
     "name:kor_x_preferred":[
         "\ucf54\ub85c\ub974 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ucf54\ub85c\ub974"
+    ],
     "name:lit_x_preferred":[
         "Kororas"
     ],
     "name:msa_x_preferred":[
+        "Koror"
+    ],
+    "name:nah_x_preferred":[
+        "Koror"
+    ],
+    "name:nau_x_preferred":[
         "Koror"
     ],
     "name:nld_x_preferred":[
@@ -108,6 +135,9 @@
     "name:por_x_preferred":[
         "Koror"
     ],
+    "name:ron_x_preferred":[
+        "Koror"
+    ],
     "name:rus_x_preferred":[
         "\u041a\u043e\u0440\u043e\u0440"
     ],
@@ -116,6 +146,9 @@
     ],
     "name:swe_x_preferred":[
         "Koror"
+    ],
+    "name:szl_x_preferred":[
+        "Koror City"
     ],
     "name:tha_x_preferred":[
         "\u0e04\u0e2d\u0e23\u0e2d\u0e23\u0e4c"
@@ -136,6 +169,9 @@
         "Koror"
     ],
     "name:vie_x_preferred":[
+        "Koror"
+    ],
+    "name:war_x_preferred":[
         "Koror"
     ],
     "name:zho_x_preferred":[
@@ -258,7 +294,7 @@
         }
     ],
     "wof:id":1141908387,
-    "wof:lastmodified":1636503082,
+    "wof:lastmodified":1690856936,
     "wof:name":"Koror",
     "wof:parent_id":85676467,
     "wof:placetype":"locality",

--- a/data/421/178/129/421178129.geojson
+++ b/data/421/178/129/421178129.geojson
@@ -23,11 +23,17 @@
     "name:ara_x_preferred":[
         "\u0645\u064a\u0644\u0643\u064a\u0648\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u0644\u0643\u064a\u0648\u0643"
+    ],
     "name:ast_x_preferred":[
         "Melekeok"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0435\u043b\u0435\u043a\u0435\u043e\u043a"
+    ],
+    "name:bel_x_variant":[
+        "\u041c\u0435\u043b\u0435\u043a\u0435\u043e\u043a"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09c7\u09b2\u09c7\u0995\u09c7\u0993\u0995"
@@ -37,6 +43,9 @@
     ],
     "name:cat_x_preferred":[
         "Melekeok"
+    ],
+    "name:ceb_x_preferred":[
+        "Melekeok Village"
     ],
     "name:ces_x_preferred":[
         "Melekeok"
@@ -48,6 +57,9 @@
         "Melekeok"
     ],
     "name:deu_x_preferred":[
+        "Melekeok"
+    ],
+    "name:diq_x_preferred":[
         "Melekeok"
     ],
     "name:ell_x_preferred":[
@@ -106,6 +118,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30eb\u30ad\u30e7\u30af\u5dde"
+    ],
+    "name:jpn_x_variant":[
+        "\u30de\u30eb\u30ad\u30e7\u30af"
     ],
     "name:kat_x_preferred":[
         "\u10db\u10d4\u10da\u10d4\u10d9\u10d4\u10dd\u10d9\u10d8"
@@ -251,7 +266,7 @@
         }
     ],
     "wof:id":421178129,
-    "wof:lastmodified":1636503081,
+    "wof:lastmodified":1690856934,
     "wof:name":"Melekeok",
     "wof:parent_id":85676493,
     "wof:placetype":"locality",

--- a/data/421/188/979/421188979.geojson
+++ b/data/421/188/979/421188979.geojson
@@ -20,16 +20,31 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0631\u0648\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0631\u0648\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Koror"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u043e\u0440\u0430\u0440"
     ],
+    "name:bel_x_variant":[
+        "\u041a\u043e\u0440\u0430\u0440"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09cb\u09b0\u09cb\u09b0"
+    ],
+    "name:bul_x_preferred":[
+        "\u041a\u043e\u0440\u043e\u0440"
     ],
     "name:cat_x_preferred":[
         "Koror"
     ],
     "name:ceb_x_preferred":[
+        "Koror"
+    ],
+    "name:ces_x_preferred":[
         "Koror"
     ],
     "name:dan_x_preferred":[
@@ -74,6 +89,9 @@
     "name:hun_x_preferred":[
         "Koror"
     ],
+    "name:hye_x_preferred":[
+        "\u0554\u0578\u0580\u0578\u0580"
+    ],
     "name:ind_x_preferred":[
         "Koror"
     ],
@@ -92,10 +110,19 @@
     "name:kor_x_preferred":[
         "\ucf54\ub85c\ub974 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ucf54\ub85c\ub974"
+    ],
     "name:lit_x_preferred":[
         "Kororas"
     ],
     "name:msa_x_preferred":[
+        "Koror"
+    ],
+    "name:nah_x_preferred":[
+        "Koror"
+    ],
+    "name:nau_x_preferred":[
         "Koror"
     ],
     "name:nld_x_preferred":[
@@ -107,6 +134,9 @@
     "name:por_x_preferred":[
         "Koror"
     ],
+    "name:ron_x_preferred":[
+        "Koror"
+    ],
     "name:rus_x_preferred":[
         "\u041a\u043e\u0440\u043e\u0440"
     ],
@@ -115,6 +145,9 @@
     ],
     "name:swe_x_preferred":[
         "Koror"
+    ],
+    "name:szl_x_preferred":[
+        "Koror City"
     ],
     "name:tha_x_preferred":[
         "\u0e04\u0e2d\u0e23\u0e2d\u0e23\u0e4c"
@@ -135,6 +168,9 @@
         "Koror"
     ],
     "name:vie_x_preferred":[
+        "Koror"
+    ],
+    "name:war_x_preferred":[
         "Koror"
     ],
     "name:zho_x_preferred":[
@@ -276,7 +312,7 @@
         }
     ],
     "wof:id":421188979,
-    "wof:lastmodified":1636503081,
+    "wof:lastmodified":1690856934,
     "wof:name":"Koror",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/323/31/85632331.geojson
+++ b/data/856/323/31/85632331.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":10.0,
     "mz:min_zoom":5.0,
+    "name:abk_x_preferred":[
+        "\u041f\u0430\u043b\u0430\u0443"
+    ],
     "name:ace_x_preferred":[
         "Palau"
     ],
@@ -46,11 +49,23 @@
     "name:amh_x_variant":[
         "\u1353\u120b\u12cd"
     ],
+    "name:ami_x_preferred":[
+        "Palau"
+    ],
+    "name:ang_x_preferred":[
+        "Palau"
+    ],
+    "name:anp_x_preferred":[
+        "\u092a\u093e\u0932\u093e\u0909"
+    ],
     "name:ara_x_preferred":[
         "\u0628\u0627\u0644\u0627\u0648"
     ],
     "name:arg_x_preferred":[
         "Palau"
+    ],
+    "name:ary_x_preferred":[
+        "\u067e\u0627\u0644\u0627\u0648\u0633"
     ],
     "name:arz_x_preferred":[
         "\u0628\u0627\u0644\u0627\u0648"
@@ -60,6 +75,9 @@
     ],
     "name:ast_x_variant":[
         "Pal\u00e1u"
+    ],
+    "name:avk_x_preferred":[
+        "Belaua"
     ],
     "name:azb_x_preferred":[
         "\u067e\u0627\u0644\u0627\u0648"
@@ -76,6 +94,9 @@
     "name:bam_x_preferred":[
         "Palawu"
     ],
+    "name:ban_x_preferred":[
+        "Palau"
+    ],
     "name:bar_x_preferred":[
         "Palau"
     ],
@@ -90,6 +111,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09aa\u09be\u09b2\u09be\u0989"
+    ],
+    "name:bis_x_preferred":[
+        "Palau"
     ],
     "name:bjn_x_preferred":[
         "Palau"
@@ -130,14 +154,23 @@
     "name:che_x_preferred":[
         "\u041f\u0430\u043b\u0430\u0443"
     ],
+    "name:chr_x_preferred":[
+        "\u13c6\u13b4\u13a0\u13eb"
+    ],
     "name:chv_x_preferred":[
         "\u041f\u0430\u043b\u0430\u0443"
+    ],
+    "name:chy_x_preferred":[
+        "Palau"
     ],
     "name:ckb_x_preferred":[
         "\u067e\u0627\u0644\u0627\u0648"
     ],
     "name:cor_x_preferred":[
         "Palau"
+    ],
+    "name:cos_x_preferred":[
+        "Pelau"
     ],
     "name:crh_x_preferred":[
         "Palau"
@@ -146,6 +179,9 @@
         "Palaw"
     ],
     "name:cym_x_variant":[
+        "Palau"
+    ],
+    "name:dag_x_preferred":[
         "Palau"
     ],
     "name:dan_x_preferred":[
@@ -219,6 +255,9 @@
     "name:frp_x_preferred":[
         "Palaos"
     ],
+    "name:frr_x_preferred":[
+        "Paalau"
+    ],
     "name:fry_x_preferred":[
         "Palau"
     ],
@@ -227,6 +266,9 @@
     ],
     "name:gag_x_preferred":[
         "Palau"
+    ],
+    "name:gcr_x_preferred":[
+        "Palaos"
     ],
     "name:ger_x_variant":[
         "Palauinseln",
@@ -249,6 +291,9 @@
     ],
     "name:gom_x_preferred":[
         "\u092a\u0932\u093e\u090a"
+    ],
+    "name:gpe_x_preferred":[
+        "Palau"
     ],
     "name:grn_x_preferred":[
         "Pal\u00e1u"
@@ -313,6 +358,9 @@
     "name:ind_x_preferred":[
         "Palau"
     ],
+    "name:inh_x_preferred":[
+        "\u041f\u0430\u043b\u0430\u0443"
+    ],
     "name:isl_x_preferred":[
         "Pal\u00e1"
     ],
@@ -350,6 +398,9 @@
     "name:kaz_x_preferred":[
         "\u041f\u0430\u043b\u0430\u0443 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430\u0441\u044b"
     ],
+    "name:kcg_x_preferred":[
+        "Pa\u0331la\u0331u"
+    ],
     "name:khm_x_preferred":[
         "\u1794\u17c9\u17b6\u17a1\u17b6\u179c"
     ],
@@ -365,6 +416,9 @@
     "name:kor_x_preferred":[
         "\ud314\ub77c\uc6b0"
     ],
+    "name:krj_x_preferred":[
+        "Kapalauhan"
+    ],
     "name:ksh_x_preferred":[
         "Palau"
     ],
@@ -376,6 +430,9 @@
     ],
     "name:lat_x_preferred":[
         "Belavia"
+    ],
+    "name:lat_x_variant":[
+        "Palau"
     ],
     "name:lav_x_preferred":[
         "Palau"
@@ -393,6 +450,9 @@
         "Palau"
     ],
     "name:lit_x_preferred":[
+        "Palau"
+    ],
+    "name:lld_x_preferred":[
         "Palau"
     ],
     "name:lmo_x_preferred":[
@@ -422,6 +482,12 @@
     "name:mar_x_variant":[
         "\u092a\u0932\u093e\u090a"
     ],
+    "name:mhr_x_preferred":[
+        "\u041f\u0430\u043b\u0430\u0443"
+    ],
+    "name:min_x_preferred":[
+        "Palau"
+    ],
     "name:mkd_x_preferred":[
         "\u041f\u0430\u043b\u0430\u0443"
     ],
@@ -434,8 +500,14 @@
     "name:mlt_x_variant":[
         "Palaw"
     ],
+    "name:mni_x_preferred":[
+        "\uabc4\uabe5\uabc2\uabe5\uabce"
+    ],
     "name:mon_x_preferred":[
         "\u041f\u0430\u043b\u0430\u0443"
+    ],
+    "name:mri_x_preferred":[
+        "P\u0101rau"
     ],
     "name:mrj_x_preferred":[
         "\u041f\u0430\u043b\u0430\u0443"
@@ -524,8 +596,14 @@
     "name:pau_x_variant":[
         "Beluu er a Belau"
     ],
+    "name:pcd_x_preferred":[
+        "Palaos"
+    ],
     "name:pih_x_preferred":[
         "Palau"
+    ],
+    "name:pli_x_preferred":[
+        "\u092a\u0932\u093e\u090a"
     ],
     "name:pms_x_preferred":[
         "Palau (rep\u00f9blica)"
@@ -544,6 +622,9 @@
     ],
     "name:pus_x_preferred":[
         "\u067e\u0627\u0644\u0627\u0648"
+    ],
+    "name:pus_x_variant":[
+        "\u067e\u0627\u0644\u0627\u06cc\u0648"
     ],
     "name:que_x_preferred":[
         "Palaw"
@@ -566,6 +647,9 @@
     "name:sah_x_preferred":[
         "\u041f\u0430\u043b\u0430\u0443"
     ],
+    "name:sat_x_preferred":[
+        "\u1c6f\u1c5f\u1c5e\u1c5f\u1c63"
+    ],
     "name:scn_x_preferred":[
         "Palau (statu)"
     ],
@@ -577,6 +661,9 @@
     ],
     "name:sgs_x_preferred":[
         "Palau"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1015\u1083\u1087\u101c\u1062\u101d\u103a\u1038"
     ],
     "name:sin_x_preferred":[
         "\u0db4\u0dbd\u0dcf\u0dc0\u0dd4"
@@ -593,7 +680,13 @@
     "name:sme_x_preferred":[
         "Palau"
     ],
+    "name:smn_x_preferred":[
+        "Palau"
+    ],
     "name:smo_x_preferred":[
+        "Palau"
+    ],
+    "name:sms_x_preferred":[
         "Palau"
     ],
     "name:sna_x_preferred":[
@@ -614,6 +707,9 @@
     "name:sqi_x_preferred":[
         "Palau"
     ],
+    "name:srd_x_preferred":[
+        "Palau"
+    ],
     "name:srp_x_preferred":[
         "\u041f\u0430\u043b\u0430\u0443"
     ],
@@ -627,6 +723,9 @@
         "Palau"
     ],
     "name:szl_x_preferred":[
+        "Palau"
+    ],
+    "name:szy_x_preferred":[
         "Palau"
     ],
     "name:tah_x_preferred":[
@@ -666,11 +765,17 @@
     "name:ton_x_preferred":[
         "Palau"
     ],
+    "name:trv_x_preferred":[
+        "Poryo"
+    ],
     "name:tuk_x_preferred":[
         "Palau"
     ],
     "name:tur_x_preferred":[
         "Palau"
+    ],
+    "name:udm_x_preferred":[
+        "\u041f\u0430\u043b\u0430\u0443"
     ],
     "name:uig_x_preferred":[
         "\u067e\u0627\u0644\u0627\u06cb"
@@ -962,7 +1067,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1617827631,
+    "wof:lastmodified":1690856934,
     "wof:name":"Palau",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/764/43/85676443.geojson
+++ b/data/856/764/43/85676443.geojson
@@ -38,6 +38,12 @@
     "name:ben_x_preferred":[
         "\u098f\u0987\u09ae\u09c7\u09b2\u09bf\u0995"
     ],
+    "name:cat_x_preferred":[
+        "Aimeliik"
+    ],
+    "name:ces_x_preferred":[
+        "Aimeliik"
+    ],
     "name:dan_x_preferred":[
         "Aimeliik"
     ],
@@ -55,6 +61,9 @@
     ],
     "name:est_x_variant":[
         "Aimeliik"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u06cc\u0645\u0644\u06cc\u06a9"
     ],
     "name:fin_x_preferred":[
         "Aimeliik"
@@ -112,6 +121,9 @@
     ],
     "name:msa_x_preferred":[
         "Aimeliik"
+    ],
+    "name:nan_x_preferred":[
+        "Aimeliik Chiu"
     ],
     "name:nld_x_preferred":[
         "Aimeliik"
@@ -290,7 +302,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503079,
+    "wof:lastmodified":1690856931,
     "wof:name":"Aimeliik",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/49/85676449.geojson
+++ b/data/856/764/49/85676449.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u098f\u0987\u09b0\u09be\u09af\u09bc"
     ],
+    "name:ces_x_preferred":[
+        "Airai"
+    ],
     "name:dan_x_preferred":[
         "Airai"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:est_x_variant":[
         "Airai"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0633\u062a\u0627\u0646 \u0627\u06cc\u0631\u0627\u06cc\u06cc"
     ],
     "name:fin_x_preferred":[
         "Airai"
@@ -112,6 +118,9 @@
     ],
     "name:msa_x_preferred":[
         "Airai"
+    ],
+    "name:nan_x_preferred":[
+        "Airai Chiu"
     ],
     "name:nld_x_preferred":[
         "Airai"
@@ -290,7 +299,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503080,
+    "wof:lastmodified":1690856932,
     "wof:name":"Airai",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/53/85676453.geojson
+++ b/data/856/764/53/85676453.geojson
@@ -33,6 +33,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0644\u0627\u064a\u0629 \u0623\u0646\u063a\u0627\u0648\u0631"
     ],
+    "name:bcl_x_preferred":[
+        "Angaur"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0410\u043d\u0433\u0430\u0443\u0440"
     ],
@@ -43,6 +46,9 @@
         "Angaur"
     ],
     "name:ceb_x_preferred":[
+        "Angaur"
+    ],
+    "name:ces_x_preferred":[
         "Angaur"
     ],
     "name:dan_x_preferred":[
@@ -56,6 +62,9 @@
     ],
     "name:eng_x_preferred":[
         "Angaur"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0646\u06af\u0648\u0631"
     ],
     "name:fin_x_preferred":[
         "Angaur"
@@ -116,6 +125,9 @@
     ],
     "name:msa_x_preferred":[
         "Angaur"
+    ],
+    "name:nan_x_preferred":[
+        "Angaur Chiu"
     ],
     "name:nld_x_preferred":[
         "Angaur"
@@ -287,7 +299,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503079,
+    "wof:lastmodified":1690856931,
     "wof:name":"Angaur",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/57/85676457.geojson
+++ b/data/856/764/57/85676457.geojson
@@ -114,6 +114,9 @@
     "name:msa_x_preferred":[
         "Hatohobei"
     ],
+    "name:nan_x_preferred":[
+        "Hatohobei Chiu"
+    ],
     "name:nld_x_preferred":[
         "Hatohobei"
     ],
@@ -285,7 +288,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503078,
+    "wof:lastmodified":1690856929,
     "wof:name":"Hatobohei",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/61/85676461.geojson
+++ b/data/856/764/61/85676461.geojson
@@ -48,6 +48,9 @@
     "name:eng_x_preferred":[
         "Kayangel"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u06cc\u0627\u0646\u06af\u0644"
+    ],
     "name:fin_x_preferred":[
         "Kayangel"
     ],
@@ -96,11 +99,17 @@
     "name:mar_x_preferred":[
         "\u0915\u093e\u092f\u0923\u0917\u0947\u0932\u0902"
     ],
+    "name:mkd_x_preferred":[
+        "\u041a\u0430\u0458\u0430\u043d\u0433\u0435\u043b"
+    ],
     "name:mrj_x_preferred":[
         "\u041a\u0430\u044f\u043d\u0433\u0435\u043b"
     ],
     "name:msa_x_preferred":[
         "Kayangel"
+    ],
+    "name:nan_x_preferred":[
+        "Kayangel Chiu"
     ],
     "name:nld_x_preferred":[
         "Kayangel"
@@ -276,7 +285,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503078,
+    "wof:lastmodified":1690856929,
     "wof:name":"Kayangel",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/67/85676467.geojson
+++ b/data/856/764/67/85676467.geojson
@@ -39,8 +39,17 @@
     "name:ara_x_variant":[
         "\u0643\u0648\u0631\u0648\u0631"
     ],
+    "name:arg_x_preferred":[
+        "Koror"
+    ],
+    "name:ast_x_preferred":[
+        "Koror"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u043e\u0440\u0430\u0440"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u043e\u0440\u0430\u0440"
     ],
     "name:ben_x_preferred":[
         "\u0995\u09cb\u09b0\u09be"
@@ -48,10 +57,16 @@
     "name:bod_x_preferred":[
         "\u0f41\u0f7c\u0f0b\u0f62\u0f7c\u0f62\u0f0d"
     ],
+    "name:bre_x_preferred":[
+        "Koror"
+    ],
     "name:cat_x_preferred":[
         "Koror"
     ],
     "name:ces_x_preferred":[
+        "Koror"
+    ],
+    "name:cos_x_preferred":[
         "Koror"
     ],
     "name:dan_x_preferred":[
@@ -66,6 +81,9 @@
     "name:eng_x_preferred":[
         "Koror"
     ],
+    "name:epo_x_preferred":[
+        "Koror"
+    ],
     "name:eus_x_preferred":[
         "Koror"
     ],
@@ -76,6 +94,9 @@
         "Koror"
     ],
     "name:fra_x_preferred":[
+        "Koror"
+    ],
+    "name:glg_x_preferred":[
         "Koror"
     ],
     "name:guj_x_preferred":[
@@ -100,6 +121,12 @@
         "\u053f\u0578\u0580\u0578\u0580"
     ],
     "name:ido_x_preferred":[
+        "Koror"
+    ],
+    "name:ile_x_preferred":[
+        "Koror"
+    ],
+    "name:ina_x_preferred":[
         "Koror"
     ],
     "name:ind_x_preferred":[
@@ -129,11 +156,20 @@
     "name:kor_x_variant":[
         "\ucf54\ub85c\ub974"
     ],
+    "name:lad_x_preferred":[
+        "Koror"
+    ],
+    "name:lat_x_preferred":[
+        "Koror"
+    ],
     "name:lav_x_preferred":[
         "Korora"
     ],
     "name:lit_x_preferred":[
         "Kororas"
+    ],
+    "name:lmo_x_preferred":[
+        "Koror"
     ],
     "name:mar_x_preferred":[
         "\u0915\u094b\u0930\u094b\u0930"
@@ -162,6 +198,12 @@
     "name:nor_x_preferred":[
         "Koror"
     ],
+    "name:nov_x_preferred":[
+        "Koror"
+    ],
+    "name:nrm_x_preferred":[
+        "Koror"
+    ],
     "name:oci_x_preferred":[
         "Koror"
     ],
@@ -169,6 +211,15 @@
         "Koror"
     ],
     "name:por_x_preferred":[
+        "Koror"
+    ],
+    "name:roh_x_preferred":[
+        "Koror"
+    ],
+    "name:ron_x_preferred":[
+        "Koror"
+    ],
+    "name:rup_x_preferred":[
         "Koror"
     ],
     "name:rus_x_preferred":[
@@ -348,7 +399,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503079,
+    "wof:lastmodified":1690856930,
     "wof:name":"Koror",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/71/85676471.geojson
+++ b/data/856/764/71/85676471.geojson
@@ -56,6 +56,9 @@
     "name:est_x_preferred":[
         "Melekeoki osariik"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0644\u06a9\u06cc\u06a9"
+    ],
     "name:fin_x_preferred":[
         "Melekeok"
     ],
@@ -107,11 +110,17 @@
     "name:lmo_x_preferred":[
         "Melekeok"
     ],
+    "name:ltz_x_preferred":[
+        "Melekeok State"
+    ],
     "name:mar_x_preferred":[
         "\u092e\u0947\u0932\u0947\u0915\u0947\u0915"
     ],
     "name:msa_x_preferred":[
         "Melekeok"
+    ],
+    "name:nan_x_preferred":[
+        "Melekeok Chiu"
     ],
     "name:nld_x_preferred":[
         "Melekeok"
@@ -292,7 +301,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503080,
+    "wof:lastmodified":1690856932,
     "wof:name":"Melekeok",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/75/85676475.geojson
+++ b/data/856/764/75/85676475.geojson
@@ -47,6 +47,9 @@
     "name:eng_x_preferred":[
         "Ngaraard"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u06af\u0627\u0631\u0627\u0631\u062f"
+    ],
     "name:fin_x_preferred":[
         "Ngaraard"
     ],
@@ -100,6 +103,9 @@
     ],
     "name:msa_x_preferred":[
         "Ngaraard"
+    ],
+    "name:nan_x_preferred":[
+        "Ngaraard Chiu"
     ],
     "name:nld_x_preferred":[
         "Ngaraard"
@@ -272,7 +278,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503079,
+    "wof:lastmodified":1690856931,
     "wof:name":"Ngaraard",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/79/85676479.geojson
+++ b/data/856/764/79/85676479.geojson
@@ -48,6 +48,9 @@
     "name:eng_x_preferred":[
         "Ngarchelong"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u06af\u0627\u0631\u0686\u0644\u0648\u0646\u06af"
+    ],
     "name:fin_x_preferred":[
         "Ngarchelong"
     ],
@@ -98,6 +101,9 @@
     ],
     "name:msa_x_preferred":[
         "Ngarchelong"
+    ],
+    "name:nan_x_preferred":[
+        "Ngarchelong Chiu"
     ],
     "name:nld_x_preferred":[
         "Ngarchelong"
@@ -273,7 +279,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503080,
+    "wof:lastmodified":1690856932,
     "wof:name":"Ngarchelong",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/85/85676485.geojson
+++ b/data/856/764/85/85676485.geojson
@@ -48,6 +48,9 @@
     "name:eng_x_preferred":[
         "Ngardmau"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u06af\u0627\u0631\u062f\u0645\u0627\u0648"
+    ],
     "name:fin_x_preferred":[
         "Ngardmau"
     ],
@@ -98,6 +101,9 @@
     ],
     "name:msa_x_preferred":[
         "Ngardmau"
+    ],
+    "name:nan_x_preferred":[
+        "Ngardmau Chiu"
     ],
     "name:nld_x_preferred":[
         "Ngardmau"
@@ -270,7 +276,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503080,
+    "wof:lastmodified":1690856932,
     "wof:name":"Ngardmau",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/89/85676489.geojson
+++ b/data/856/764/89/85676489.geojson
@@ -47,6 +47,9 @@
     "name:eng_x_preferred":[
         "Ngatpang"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u06af\u0627\u062a\u067e\u0627\u0646\u06af"
+    ],
     "name:fin_x_preferred":[
         "Ngatpang"
     ],
@@ -55,6 +58,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0aa8\u0acd\u0a97\u0abe\u0aa4\u0aaa\u0abe\u0a82\u0a97"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e0\u05d2\u05d8\u05e4\u05e0\u05d2"
     ],
     "name:hin_x_preferred":[
         "\u0917\u0948\u0924\u094d\u092a\u0948\u0902\u0917"
@@ -100,6 +106,9 @@
     ],
     "name:msa_x_preferred":[
         "Ngatpang"
+    ],
+    "name:nan_x_preferred":[
+        "Ngatpang Chiu"
     ],
     "name:nld_x_preferred":[
         "Ngatpang"
@@ -272,7 +281,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503079,
+    "wof:lastmodified":1690856930,
     "wof:name":"Ngatpang",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/93/85676493.geojson
+++ b/data/856/764/93/85676493.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u0997\u099a\u09c7\u09b8\u09be\u09b0"
     ],
+    "name:cat_x_preferred":[
+        "Ngchesar"
+    ],
     "name:dan_x_preferred":[
         "Ngchesar"
     ],
@@ -46,6 +49,9 @@
     ],
     "name:eng_x_preferred":[
         "Ngchesar"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u06af\u0686\u0633\u0627\u0631"
     ],
     "name:fin_x_preferred":[
         "Ngchesar"
@@ -97,6 +103,9 @@
     ],
     "name:msa_x_preferred":[
         "Ngchesar"
+    ],
+    "name:nan_x_preferred":[
+        "Ngchesar Chiu"
     ],
     "name:nld_x_preferred":[
         "Ngchesar"
@@ -271,7 +280,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503079,
+    "wof:lastmodified":1690856930,
     "wof:name":"Ngchesar",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/97/85676497.geojson
+++ b/data/856/764/97/85676497.geojson
@@ -107,6 +107,9 @@
     "name:msa_x_preferred":[
         "Ngeremlengui"
     ],
+    "name:nan_x_preferred":[
+        "Ngeremlengui Chiu"
+    ],
     "name:nld_x_preferred":[
         "Ngeremlengui"
     ],
@@ -274,7 +277,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503080,
+    "wof:lastmodified":1690856931,
     "wof:name":"Ngeremlengui",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/765/03/85676503.geojson
+++ b/data/856/765/03/85676503.geojson
@@ -47,6 +47,9 @@
     "name:eng_x_preferred":[
         "Ngiwal"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u06af\u06cc\u0648\u0627\u0644"
+    ],
     "name:fin_x_preferred":[
         "Ngiwal"
     ],
@@ -97,6 +100,9 @@
     ],
     "name:msa_x_preferred":[
         "Ngiwal"
+    ],
+    "name:nan_x_preferred":[
+        "Ngiwal Chiu"
     ],
     "name:nld_x_preferred":[
         "Ngiwal"
@@ -269,7 +275,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503080,
+    "wof:lastmodified":1690856933,
     "wof:name":"Ngiwal",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/765/07/85676507.geojson
+++ b/data/856/765/07/85676507.geojson
@@ -33,6 +33,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0644\u0627\u064a\u0629 \u0628\u064a\u0644\u064a\u0644\u064a\u0648"
     ],
+    "name:bcl_x_preferred":[
+        "Peleliu"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09c7\u09b2\u09c7\u09b2\u09bf\u0989"
     ],
@@ -40,6 +43,9 @@
         "Peleliu"
     ],
     "name:ceb_x_preferred":[
+        "Peleliu"
+    ],
+    "name:ces_x_preferred":[
         "Peleliu"
     ],
     "name:dan_x_preferred":[
@@ -56,6 +62,9 @@
     ],
     "name:epo_x_preferred":[
         "Peleliu"
+    ],
+    "name:fas_x_preferred":[
+        "\u067e\u0644\u06cc\u0644\u06cc\u0648"
     ],
     "name:fin_x_preferred":[
         "Peleliu"
@@ -296,7 +305,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503081,
+    "wof:lastmodified":1690856933,
     "wof:name":"Peleliu",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/765/09/85676509.geojson
+++ b/data/856/765/09/85676509.geojson
@@ -62,6 +62,9 @@
     "name:fra_x_preferred":[
         "Sonsorol"
     ],
+    "name:frr_x_preferred":[
+        "Sonsorol"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0aa8\u0acd\u0ab8\u0acb\u0ab0\u0acb\u0ab2"
     ],
@@ -107,11 +110,17 @@
     "name:mar_x_preferred":[
         "\u0938\u094b\u0902\u0938\u094b\u0932"
     ],
+    "name:mkd_x_preferred":[
+        "\u0421\u043e\u043d\u0441\u043e\u0440\u043e\u043b"
+    ],
     "name:mrj_x_preferred":[
         "\u0421\u043e\u043d\u0441\u043e\u0440\u043e\u043b"
     ],
     "name:msa_x_preferred":[
         "Sonsorol"
+    ],
+    "name:nan_x_preferred":[
+        "Sonsorol Chiu"
     ],
     "name:nld_x_preferred":[
         "Sonsorol"
@@ -287,7 +296,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1636503081,
+    "wof:lastmodified":1690856933,
     "wof:name":"Sonsorol",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/890/427/535/890427535.geojson
+++ b/data/890/427/535/890427535.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "Kayangel"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u06cc\u0627\u0646\u06af\u0644"
+    ],
     "name:fin_x_preferred":[
         "Kayangel"
     ],
@@ -82,11 +85,17 @@
     "name:mar_x_preferred":[
         "\u0915\u093e\u092f\u0923\u0917\u0947\u0932\u0902"
     ],
+    "name:mkd_x_preferred":[
+        "\u041a\u0430\u0458\u0430\u043d\u0433\u0435\u043b"
+    ],
     "name:mrj_x_preferred":[
         "\u041a\u0430\u044f\u043d\u0433\u0435\u043b"
     ],
     "name:msa_x_preferred":[
         "Kayangel"
+    ],
+    "name:nan_x_preferred":[
+        "Kayangel Chiu"
     ],
     "name:nld_x_preferred":[
         "Kayangel"
@@ -166,7 +175,7 @@
         }
     ],
     "wof:id":890427535,
-    "wof:lastmodified":1636503082,
+    "wof:lastmodified":1690856935,
     "wof:name":"Kayangel",
     "wof:parent_id":85676461,
     "wof:placetype":"locality",

--- a/data/890/443/883/890443883.geojson
+++ b/data/890/443/883/890443883.geojson
@@ -25,17 +25,26 @@
     "name:ara_x_preferred":[
         "\u0645\u064a\u0644\u0643\u064a\u0648\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u0644\u0643\u064a\u0648\u0643"
+    ],
     "name:ast_x_preferred":[
         "Melekeok"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0435\u043b\u0435\u043a\u0435\u043e\u043a"
     ],
+    "name:bel_x_variant":[
+        "\u041c\u0435\u043b\u0435\u043a\u0435\u043e\u043a"
+    ],
     "name:bul_x_preferred":[
         "\u041c\u0435\u043b\u0435\u043a\u0435\u043e\u043a"
     ],
     "name:cat_x_preferred":[
         "Melekeok"
+    ],
+    "name:ceb_x_preferred":[
+        "Melekeok Village"
     ],
     "name:ces_x_preferred":[
         "Melekeok"
@@ -47,6 +56,9 @@
         "Melekeok"
     ],
     "name:deu_x_preferred":[
+        "Melekeok"
+    ],
+    "name:diq_x_preferred":[
         "Melekeok"
     ],
     "name:ell_x_preferred":[
@@ -96,6 +108,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30eb\u30ad\u30e7\u30af\u5dde"
+    ],
+    "name:jpn_x_variant":[
+        "\u30de\u30eb\u30ad\u30e7\u30af"
     ],
     "name:kat_x_preferred":[
         "\u10db\u10d4\u10da\u10d4\u10d9\u10d4\u10dd\u10d9\u10d8"
@@ -318,7 +333,7 @@
         }
     ],
     "wof:id":890443883,
-    "wof:lastmodified":1566609234,
+    "wof:lastmodified":1690856935,
     "wof:name":"Melekeok Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/450/167/890450167.geojson
+++ b/data/890/450/167/890450167.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0644\u0627\u064a\u0629 \u0628\u064a\u0644\u064a\u0644\u064a\u0648"
     ],
+    "name:bcl_x_preferred":[
+        "Peleliu"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09c7\u09b2\u09c7\u09b2\u09bf\u0989"
     ],
@@ -29,6 +32,9 @@
         "Peleliu"
     ],
     "name:ceb_x_preferred":[
+        "Peleliu"
+    ],
+    "name:ces_x_preferred":[
         "Peleliu"
     ],
     "name:dan_x_preferred":[
@@ -45,6 +51,9 @@
     ],
     "name:epo_x_preferred":[
         "Peleliu"
+    ],
+    "name:fas_x_preferred":[
+        "\u067e\u0644\u06cc\u0644\u06cc\u0648"
     ],
     "name:fin_x_preferred":[
         "Peleliu"
@@ -191,7 +200,7 @@
         }
     ],
     "wof:id":890450167,
-    "wof:lastmodified":1636503082,
+    "wof:lastmodified":1690856935,
     "wof:name":"Peleliu",
     "wof:parent_id":85676507,
     "wof:placetype":"locality",

--- a/data/890/450/177/890450177.geojson
+++ b/data/890/450/177/890450177.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0644\u0627\u064a\u0629 \u0623\u0646\u063a\u0627\u0648\u0631"
     ],
+    "name:bcl_x_preferred":[
+        "Angaur"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0410\u043d\u0433\u0430\u0443\u0440"
     ],
@@ -32,6 +35,9 @@
         "Angaur"
     ],
     "name:ceb_x_preferred":[
+        "Angaur"
+    ],
+    "name:ces_x_preferred":[
         "Angaur"
     ],
     "name:dan_x_preferred":[
@@ -45,6 +51,9 @@
     ],
     "name:eng_x_preferred":[
         "Angaur"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0646\u06af\u0648\u0631"
     ],
     "name:fin_x_preferred":[
         "Angaur"
@@ -102,6 +111,9 @@
     ],
     "name:msa_x_preferred":[
         "Angaur"
+    ],
+    "name:nan_x_preferred":[
+        "Angaur Chiu"
     ],
     "name:nld_x_preferred":[
         "Angaur"
@@ -188,7 +200,7 @@
         }
     ],
     "wof:id":890450177,
-    "wof:lastmodified":1636503082,
+    "wof:lastmodified":1690856936,
     "wof:name":"Angaur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/450/179/890450179.geojson
+++ b/data/890/450/179/890450179.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":-1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0628\u0627\u0628\u0644\u062f\u0623\u0648\u0628"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0411\u0430\u0431\u0435\u043b\u0434\u0430\u0430\u0431"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:eng_x_variant":[
         "Babelthuap"
+    ],
+    "name:epo_x_preferred":[
+        "Babeldaob"
     ],
     "name:est_x_preferred":[
         "Babelthuap"
@@ -139,6 +145,9 @@
     "name:und_x_variant":[
         "Baubelthouap"
     ],
+    "name:urd_x_preferred":[
+        "\u0628\u0627\u0628\u0644\u062f\u0627\u0648\u0628"
+    ],
     "name:vie_x_preferred":[
         "Babeldaob"
     ],
@@ -175,7 +184,7 @@
         }
     ],
     "wof:id":890450179,
-    "wof:lastmodified":1566609235,
+    "wof:lastmodified":1690856936,
     "wof:name":"Babeldaob",
     "wof:parent_id":85676497,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.