### PR TITLE
pw concordances, placetype local, and more

### DIFF
--- a/data/856/323/31/85632331.geojson
+++ b/data/856/323/31/85632331.geojson
@@ -1038,6 +1038,7 @@
         "hasc:id":"PW",
         "icao:code":"T8A",
         "ioc:id":"PLW",
+        "iso:code":"PW",
         "itu:id":"PLW",
         "m49:code":"585",
         "marc:id":"pw",
@@ -1049,6 +1050,7 @@
         "wd:id":"Q695",
         "wk:page":"Palau"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
     "wof:country_alpha3":"PLW",
     "wof:geom_alt":[
@@ -1071,7 +1073,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1694639558,
+    "wof:lastmodified":1695881217,
     "wof:name":"Palau",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/764/43/85676443.geojson
+++ b/data/856/764/43/85676443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00361,
-    "geom:area_square_m":44266740.548151,
+    "geom:area_square_m":44266277.162003,
     "geom:bbox":"134.482921,7.397439,134.565735,7.47029",
     "geom:latitude":7.437434,
     "geom:longitude":134.52326,
@@ -278,14 +278,16 @@
         "gn:id":1559964,
         "gp:id":24549821,
         "hasc:id":"PW.AM",
+        "iso:code":"PW-002",
         "iso:id":"PW-002",
         "qs_pg:id":59679,
         "unlc:id":"PW-002",
         "wd:id":"Q405589",
         "wk:page":"Aimeliik"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"d5dac4518fa6547668eda938d0102ddd",
+    "wof:geomhash":"8899d504565473af78d31d18827db38d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -302,7 +304,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856931,
+    "wof:lastmodified":1695884947,
     "wof:name":"Aimeliik",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/49/85676449.geojson
+++ b/data/856/764/49/85676449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003973,
-    "geom:area_square_m":48721328.638075,
+    "geom:area_square_m":48721592.068089,
     "geom:bbox":"134.510531,7.355699,134.601085,7.431996",
     "geom:latitude":7.391894,
     "geom:longitude":134.560134,
@@ -275,14 +275,16 @@
         "gn:id":4037645,
         "gp:id":24549819,
         "hasc:id":"PW.AR",
+        "iso:code":"PW-004",
         "iso:id":"PW-004",
         "qs_pg:id":354722,
         "unlc:id":"PW-004",
         "wd:id":"Q407967",
         "wk:page":"Airai"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"495baa27f97f47fbeeccfe2ea7286fba",
+    "wof:geomhash":"0cb21ca00818bbac5e3be04259c20e3e",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -299,7 +301,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856932,
+    "wof:lastmodified":1695884947,
     "wof:name":"Airai",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/53/85676453.geojson
+++ b/data/856/764/53/85676453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001437,
-    "geom:area_square_m":17638382.3557,
+    "geom:area_square_m":17638531.291603,
     "geom:bbox":"134.136729,6.884467,134.177745,6.935004",
     "geom:latitude":6.912461,
     "geom:longitude":134.157537,
@@ -276,13 +276,15 @@
         "gn:id":4037653,
         "gp:id":24549824,
         "hasc:id":"PW.AN",
+        "iso:code":"PW-010",
         "iso:id":"PW-010",
         "qs_pg:id":49433,
         "unlc:id":"PW-010",
         "wd:id":"Q530813"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"874cd7df82c50509f6c884bb1f2c4498",
+    "wof:geomhash":"8d27e373182f72810298299ccd0c9332",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -299,7 +301,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856931,
+    "wof:lastmodified":1695884947,
     "wof:name":"Angaur",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/57/85676457.geojson
+++ b/data/856/764/57/85676457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002283,
-    "geom:area_square_m":28195815.777759,
+    "geom:area_square_m":28195923.849852,
     "geom:bbox":"131.131114,2.949042,131.812999,3.060289",
     "geom:latitude":3.015861,
     "geom:longitude":131.361915,
@@ -264,14 +264,16 @@
         "gn:id":1559776,
         "gp:id":24549812,
         "hasc:id":"PW.HA",
+        "iso:code":"PW-050",
         "iso:id":"PW-050",
         "qs_pg:id":59674,
         "unlc:id":"PW-050",
         "wd:id":"Q3516752",
         "wk:page":"Hatohobei"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"5cca1877c1455aac5fedd7f6d0fb32e2",
+    "wof:geomhash":"466d9202f33263537909d5b2b110856c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -288,7 +290,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856929,
+    "wof:lastmodified":1695884947,
     "wof:name":"Hatobohei",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/61/85676461.geojson
+++ b/data/856/764/61/85676461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001086,
-    "geom:area_square_m":13290594.798908,
+    "geom:area_square_m":13290759.581379,
     "geom:bbox":"134.692525,8.050245,134.727343,8.096618",
     "geom:latitude":8.074311,
     "geom:longitude":134.709484,
@@ -261,14 +261,16 @@
         "gn:id":1559774,
         "gp:id":24549826,
         "hasc:id":"PW.KA",
+        "iso:code":"PW-100",
         "iso:id":"PW-100",
         "qs_pg:id":507420,
         "unlc:id":"PW-100",
         "wd:id":"Q871222",
         "wk:page":"Kayangel"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"7bdaf588e45715075b615bafbfd46995",
+    "wof:geomhash":"8eca44ebad8bb94a3b2d998c58d2de2b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -285,7 +287,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856929,
+    "wof:lastmodified":1695884947,
     "wof:name":"Kayangel",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/67/85676467.geojson
+++ b/data/856/764/67/85676467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004781,
-    "geom:area_square_m":58636525.733269,
+    "geom:area_square_m":58636303.84139,
     "geom:bbox":"134.347179,7.219143,134.527354,7.362698",
     "geom:latitude":7.2888,
     "geom:longitude":134.438135,
@@ -375,14 +375,16 @@
         "gn:id":4037892,
         "gp:id":24549822,
         "hasc:id":"PW.KO",
+        "iso:code":"PW-150",
         "iso:id":"PW-150",
         "qs_pg:id":219956,
         "unlc:id":"PW-150",
         "wd:id":"Q189426",
         "wk:page":"Koror"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"3ffbafe9bb00123f4500800ad814331e",
+    "wof:geomhash":"bc302cb539117a66339bd570087e2d54",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -399,7 +401,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856930,
+    "wof:lastmodified":1695884947,
     "wof:name":"Koror",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/71/85676471.geojson
+++ b/data/856/764/71/85676471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001347,
-    "geom:area_square_m":16515377.689243,
+    "geom:area_square_m":16515247.20038,
     "geom:bbox":"134.594689,7.488036,134.635997,7.542207",
     "geom:latitude":7.512841,
     "geom:longitude":134.615312,
@@ -278,13 +278,15 @@
         "gn:id":4037930,
         "gp:id":24549818,
         "hasc:id":"PW.ME",
+        "iso:code":"PW-212",
         "iso:id":"PW-212",
         "qs_pg:id":59678,
         "unlc:id":"PW-212",
         "wd:id":"Q12898552"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"916ebbb9a1a1c59e2cd3dfd16941f42a",
+    "wof:geomhash":"a156358676fe149ca69f1ef56c627989",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -301,7 +303,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856932,
+    "wof:lastmodified":1695884947,
     "wof:name":"Melekeok",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/75/85676475.geojson
+++ b/data/856/764/75/85676475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002573,
-    "geom:area_square_m":31527909.097702,
+    "geom:area_square_m":31527803.571373,
     "geom:bbox":"134.622949,7.591051,134.663341,7.686021",
     "geom:latitude":7.635616,
     "geom:longitude":134.646601,
@@ -254,14 +254,16 @@
         "gn:id":4037962,
         "gp:id":24549814,
         "hasc:id":"PW.ND",
+        "iso:code":"PW-214",
         "iso:id":"PW-214",
         "qs_pg:id":59676,
         "unlc:id":"PW-214",
         "wd:id":"Q1154127",
         "wk:page":"Ngaraard"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"b06533ae12b9c4938fdb6da8d541b363",
+    "wof:geomhash":"11123788c51e66f8734dbda7046311a9",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -278,7 +280,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856931,
+    "wof:lastmodified":1695884947,
     "wof:name":"Ngaraard",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/79/85676479.geojson
+++ b/data/856/764/79/85676479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001095,
-    "geom:area_square_m":13412050.841658,
+    "geom:area_square_m":13412000.267628,
     "geom:bbox":"134.62143,7.684075,134.660167,7.734076",
     "geom:latitude":7.707923,
     "geom:longitude":134.639876,
@@ -255,14 +255,16 @@
         "gn:id":4038037,
         "gp:id":24549813,
         "hasc:id":"PW.NC",
+        "iso:code":"PW-218",
         "iso:id":"PW-218",
         "qs_pg:id":59675,
         "unlc:id":"PW-218",
         "wd:id":"Q1070185",
         "wk:page":"Ngarchelong"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"45228ea0dfd705067fa7ee26f60282a9",
+    "wof:geomhash":"1cbecd004586950d20b5641cdf419115",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -279,7 +281,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856932,
+    "wof:lastmodified":1695884947,
     "wof:name":"Ngarchelong",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/85/85676485.geojson
+++ b/data/856/764/85/85676485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002709,
-    "geom:area_square_m":33204366.048786,
+    "geom:area_square_m":33204539.279636,
     "geom:bbox":"134.546397,7.573029,134.623643,7.6259",
     "geom:latitude":7.59846,
     "geom:longitude":134.590792,
@@ -252,14 +252,16 @@
         "gn:id":4038043,
         "gp:id":24549816,
         "hasc:id":"PW.NM",
+        "iso:code":"PW-222",
         "iso:id":"PW-222",
         "qs_pg:id":59677,
         "unlc:id":"PW-222",
         "wd:id":"Q1144496",
         "wk:page":"Ngardmau"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"63c765f072f34fbd7490c4c03f32050a",
+    "wof:geomhash":"9225361ce22e84aa8447d897929e8e14",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -276,7 +278,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856932,
+    "wof:lastmodified":1695884947,
     "wof:name":"Ngardmau",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/89/85676489.geojson
+++ b/data/856/764/89/85676489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003169,
-    "geom:area_square_m":38853426.729202,
+    "geom:area_square_m":38853527.467529,
     "geom:bbox":"134.487559,7.431996,134.580679,7.523527",
     "geom:latitude":7.477118,
     "geom:longitude":134.54555,
@@ -257,14 +257,16 @@
         "gn:id":1559532,
         "gp:id":24549820,
         "hasc:id":"PW.NP",
+        "iso:code":"PW-224",
         "iso:id":"PW-224",
         "qs_pg:id":219955,
         "unlc:id":"PW-224",
         "wd:id":"Q430385",
         "wk:page":"Ngatpang"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"93a0758d96ee6a3aef562d255dbba211",
+    "wof:geomhash":"e3b8747d857f36cc71358796ac908ec7",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -281,7 +283,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856930,
+    "wof:lastmodified":1695884947,
     "wof:name":"Ngatpang",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/93/85676493.geojson
+++ b/data/856/764/93/85676493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002588,
-    "geom:area_square_m":31729057.411595,
+    "geom:area_square_m":31729533.049375,
     "geom:bbox":"134.565735,7.421129,134.628194,7.51232",
     "geom:latitude":7.464335,
     "geom:longitude":134.595178,
@@ -257,13 +257,15 @@
         "gn:id":4037976,
         "gp:id":24549827,
         "hasc:id":"PW.NS",
+        "iso:code":"PW-226",
         "iso:id":"PW-226",
         "qs_pg:id":219957,
         "unlc:id":"PW-226",
         "wd:id":"Q1070180"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"4151ed34a22aa7bd0dfc4e4f896464ec",
+    "wof:geomhash":"3357ebf729d2d3523a84199fbf416396",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -280,7 +282,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856930,
+    "wof:lastmodified":1695884947,
     "wof:name":"Ngchesar",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/764/97/85676497.geojson
+++ b/data/856/764/97/85676497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005837,
-    "geom:area_square_m":71554415.944719,
+    "geom:area_square_m":71554712.577619,
     "geom:bbox":"134.511567,7.474026,134.619907,7.589841",
     "geom:latitude":7.539731,
     "geom:longitude":134.571044,
@@ -254,13 +254,15 @@
         "gn:id":4038068,
         "gp:id":24549817,
         "hasc:id":"PW.NL",
+        "iso:code":"PW-227",
         "iso:id":"PW-227",
         "qs_pg:id":1158428,
         "unlc:id":"PW-227",
         "wd:id":"Q975076"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"50e525c7bee9a8300fb5c09aa1f5ad0f",
+    "wof:geomhash":"1334122f1951a848811ad78afc7ad440",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -277,7 +279,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856931,
+    "wof:lastmodified":1695884947,
     "wof:name":"Ngeremlengui",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/765/03/85676503.geojson
+++ b/data/856/765/03/85676503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001857,
-    "geom:area_square_m":22759063.026099,
+    "geom:area_square_m":22759272.770593,
     "geom:bbox":"134.607765,7.530504,134.658214,7.600115",
     "geom:latitude":7.567434,
     "geom:longitude":134.632,
@@ -251,14 +251,16 @@
         "gn:id":4038179,
         "gp:id":24549815,
         "hasc:id":"PW.NW",
+        "iso:code":"PW-228",
         "iso:id":"PW-228",
         "qs_pg:id":354723,
         "unlc:id":"PW-228",
         "wd:id":"Q1154101",
         "wk:page":"Ngiwal"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"11b39025cee70811748b740de0ce311f",
+    "wof:geomhash":"bd4fd4491d2028d0288011dfd9359859",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -275,7 +277,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856933,
+    "wof:lastmodified":1695884947,
     "wof:name":"Ngiwal",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/765/07/85676507.geojson
+++ b/data/856/765/07/85676507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00182,
-    "geom:area_square_m":22338889.146996,
+    "geom:area_square_m":22338506.10273,
     "geom:bbox":"134.230479,6.98432,134.285004,7.07453",
     "geom:latitude":7.031387,
     "geom:longitude":134.260187,
@@ -282,13 +282,15 @@
         "gn:id":4038261,
         "gp:id":24549823,
         "hasc:id":"PW.PE",
+        "iso:code":"PW-350",
         "iso:id":"PW-350",
         "qs_pg:id":1086121,
         "unlc:id":"PW-350",
         "wd:id":"Q497981"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"66f8a1ca2cdc64939a700458252a844e",
+    "wof:geomhash":"5673c13b07de3c77fe2894e1d18567c2",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -305,7 +307,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856933,
+    "wof:lastmodified":1695884947,
     "wof:name":"Peleliu",
     "wof:parent_id":85632331,
     "wof:placetype":"region",

--- a/data/856/765/09/85676509.geojson
+++ b/data/856/765/09/85676509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000116,
-    "geom:area_square_m":1424076.118628,
+    "geom:area_square_m":1424086.316233,
     "geom:bbox":"132.213878,5.292222,132.226736,5.310248",
     "geom:latitude":5.302731,
     "geom:longitude":132.22032,
@@ -272,14 +272,16 @@
         "gn:id":1559630,
         "gp:id":24549825,
         "hasc:id":"PW.SO",
+        "iso:code":"PW-370",
         "iso:id":"PW-370",
         "qs_pg:id":59442,
         "unlc:id":"PW-370",
         "wd:id":"Q866699",
         "wk:page":"Sonsorol"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PW",
-    "wof:geomhash":"ff3a9621cfc41b943b35f9d7a5bf99d6",
+    "wof:geomhash":"419a2a84c34ac69a4ce43480f58c23f4",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -296,7 +298,7 @@
         "pau",
         "eng"
     ],
-    "wof:lastmodified":1690856933,
+    "wof:lastmodified":1695884947,
     "wof:name":"Sonsorol",
     "wof:parent_id":85632331,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.